### PR TITLE
Do not use parameters for private classes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,19 +3,7 @@
 #
 # @api private
 #
-class opensearch::config (
-  ##
-  ## opensearch settings
-  ##
-  $default_settings     = $opensearch::default_settings,
-  $settings             = $opensearch::settings,
-  $use_default_settings = $opensearch::use_default_settings,
-
-  ##
-  ## java settings
-  ##
-  $heap_size            = $opensearch::heap_size,
-) {
+class opensearch::config {
   assert_private()
 
   if $opensearch::manage_config {
@@ -24,9 +12,9 @@ class opensearch::config (
       default   => '/etc/opensearch',
     }
 
-    $data = $use_default_settings ? {
-      true  => merge($default_settings, $settings),
-      false => $settings,
+    $settings = $opensearch::use_default_settings ? {
+      true  => merge($opensearch::default_settings, $opensearch::settings),
+      false => $opensearch::settings,
     }
 
     file { "${config_directory}/opensearch.yml":
@@ -34,7 +22,7 @@ class opensearch::config (
       owner   => 'opensearch',
       group   => 'opensearch',
       mode    => '0640',
-      content => $data.to_yaml,
+      content => $settings.to_yaml,
     }
 
     file { "${config_directory}/jvm.options":
@@ -44,7 +32,7 @@ class opensearch::config (
       mode    => '0640',
       content => epp("${module_name}/jvm.options.epp",
         {
-          heap_size  => $heap_size,
+          heap_size  => $opensearch::heap_size,
         }
       ),
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,11 +30,7 @@ class opensearch::config {
       owner   => 'opensearch',
       group   => 'opensearch',
       mode    => '0640',
-      content => epp("${module_name}/jvm.options.epp",
-        {
-          heap_size  => $opensearch::heap_size,
-        }
-      ),
+      content => epp("${module_name}/jvm.options.epp"),
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,7 @@
 #
 # @api private
 #
-class opensearch::install (
-) {
+class opensearch::install {
   assert_private()
 
   if $opensearch::manage_package {

--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -3,26 +3,21 @@
 #
 # @api private
 #
-class opensearch::install::archive (
-  $architecture = $opensearch::package_architecture,
-  $directory    = $opensearch::package_directory,
-  $ensure       = $opensearch::package_ensure,
-  $version      = $opensearch::version,
-) {
+class opensearch::install::archive {
   assert_private()
 
-  $file = "opensearch-${version}-linux-${architecture}.tar.gz"
+  $file = "opensearch-${opensearch::version}-linux-${opensearch::package_architecture}.tar.gz"
 
   user { 'opensearch':
-    ensure     => $ensure,
-    home       => $directory,
+    ensure     => $opensearch::package_ensure,
+    home       => $opensearch::package_directory,
     managehome => false,
     system     => true,
     shell      => '/bin/false',
   }
 
-  if $ensure == 'present' {
-    file { $directory:
+  if $opensearch::package_ensure == 'present' {
+    file { $opensearch::package_directory:
       ensure => 'directory',
       owner  => 'opensearch',
       group  => 'opensearch',
@@ -44,29 +39,29 @@ class opensearch::install::archive (
       provider        => 'wget',
       path            => "/tmp/${file}",
       extract         => true,
-      extract_path    => $directory,
-      extract_command => "tar -xvzf /tmp/${file} --wildcards opensearch-${version}/* -C ${directory}",
+      extract_path    => $opensearch::package_directory,
+      extract_command => "tar -xvzf /tmp/${file} --wildcards opensearch-${opensearch::version}/* -C ${opensearch::package_directory}",
       user            => 'opensearch',
       group           => 'opensearch',
-      creates         => "${directory}/bin",
+      creates         => "${opensearch::package_directory}/bin",
       cleanup         => true,
-      source          => "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/${file}",
+      source          => "https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearch::version}/${file}",
     }
   } else {
-    file { $directory:
-      ensure  => $ensure,
+    file { $opensearch::package_directory:
+      ensure  => $opensearch::package_ensure,
       revsere => true,
       force   => true,
     }
 
     file { '/var/lib/opensearch':
-      ensure  => $ensure,
+      ensure  => $opensearch::package_ensure,
       revsere => true,
       force   => true,
     }
 
     file { '/var/log/opensearch':
-      ensure  => $ensure,
+      ensure  => $opensearch::package_ensure,
       revsere => true,
       force   => true,
     }

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -3,29 +3,24 @@
 #
 # @api private
 #
-class opensearch::install::package (
-  $architecture = $opensearch::package_architecture,
-  $ensure       = $opensearch::package_ensure,
-  $provider     = $opensearch::package_provider,
-  $version      = $opensearch::version,
-) {
+class opensearch::install::package {
   assert_private()
 
-  $file = $provider ? {
-    'dpkg' => "opensearch-${version}-linux-${architecture}.deb",
-    'rpm'  => "opensearch-${version}-linux-${architecture}.rpm",
+  $file = $opensearch::package_provider ? {
+    'dpkg' => "opensearch-${opensearch::version}-linux-${opensearch::package_architecture}.deb",
+    'rpm'  => "opensearch-${opensearch::version}-linux-${opensearch::package_architecture}.rpm",
   }
 
   archive { "/tmp/${file}":
     provider => 'wget',
     extract  => false,
     cleanup  => true,
-    source   => "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/${file}",
+    source   => "https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearch::version}/${file}",
   }
 
   package { 'opensearch':
-    ensure   => $ensure,
-    provider => $provider,
+    ensure   => $opensearch::package_ensure,
+    provider => $opensearch::package_provider,
     source   => "/tmp/${file}",
   }
 }

--- a/manifests/install/repository.pp
+++ b/manifests/install/repository.pp
@@ -3,8 +3,7 @@
 #
 # @api private
 #
-class opensearch::install::repository (
-) {
+class opensearch::install::repository {
   assert_private()
 
   case $facts['os']['family'] {

--- a/manifests/install/repository/debian.pp
+++ b/manifests/install/repository/debian.pp
@@ -3,15 +3,13 @@
 #
 # @api private
 #
-class opensearch::install::repository::debian (
-  $ensure = $opensearch::package_ensure,
-) {
+class opensearch::install::repository::debian {
   assert_private()
 
   include apt
 
   archive { '/tmp/opensearch.pgp':
-    ensure          => $ensure,
+    ensure          => $opensearch::package_ensure,
     source          => 'https://artifacts.opensearch.org/publickeys/opensearch.pgp',
     extract         => true,
     extract_path    => '/usr/share/keyrings',
@@ -20,7 +18,7 @@ class opensearch::install::repository::debian (
   }
 
   apt::source { 'opensearch':
-    ensure   => $ensure,
+    ensure   => $opensearch::package_ensure,
     location => 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt',
     release  => 'stable',
     repos    => 'main',
@@ -28,7 +26,7 @@ class opensearch::install::repository::debian (
   }
 
   package { 'opensearch':
-    ensure => $ensure,
+    ensure => $opensearch::package_ensure,
   }
 
   Archive['/tmp/opensearch.pgp'] -> Apt::Source['opensearch'] ~> Class['apt::update'] -> Package['opensearch']

--- a/manifests/install/repository/redhat.pp
+++ b/manifests/install/repository/redhat.pp
@@ -3,13 +3,11 @@
 #
 # @api private
 #
-class opensearch::install::repository::redhat (
-  $ensure = $opensearch::package_ensure,
-) {
+class opensearch::install::repository::redhat {
   assert_private()
 
   yumrepo { 'OpenSearch 2.x':
-    ensure        => $ensure,
+    ensure        => $opensearch::package_ensure,
     baseurl       => 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/yum',
     repo_gpgcheck => '1',
     gpgcheck      => '1',
@@ -17,7 +15,7 @@ class opensearch::install::repository::redhat (
   }
 
   package { 'opensearch':
-    ensure => $ensure,
+    ensure => $opensearch::package_ensure,
   }
 
   Yumrepo['OpenSearch 2.x'] -> Package['opensearch']

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,8 +3,7 @@
 #
 # @api private
 #
-class opensearch::service (
-) {
+class opensearch::service {
   assert_private()
 
   if $opensearch::manage_service {

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -67,6 +67,7 @@ def get_defaults(facts)
       '.replication-metadata-store',
     ],
   }
+
   {
     ##
     ## version

--- a/spec/shared_examples/config.rb
+++ b/spec/shared_examples/config.rb
@@ -12,29 +12,18 @@ shared_examples 'config' do |parameter, _facts|
   end
 
   if parameter['manage_config']
-    ##
-    ## opensearch settings
-    ##
-    default_settings     = parameter['default_settings']
-    settings             = parameter['settings']
-    use_default_settings = parameter['use_default_settings']
+    config_directory = case parameter['package_install_method']
+                       when 'archive'
+                         "#{parameter['package_directory']}/config"
+                       else
+                         '/etc/opensearch'
+                       end
 
-    ##
-    ## java settings
-    ##
-    heap_size            = parameter['heap_size']
-    config_directory     = case parameter['package_install_method']
-                           when 'archive'
-                             "#{parameter['package_directory']}/config"
-                           else
-                             '/etc/opensearch'
-                           end
-
-    data = if use_default_settings
-             default_settings.merge(settings)
-           else
-             settings
-           end
+    settings = if parameter['use_default_settings']
+                 parameter['default_settings'].merge(parameter['settings'])
+               else
+                 parameter['settings']
+               end
 
     require 'yaml'
 
@@ -45,7 +34,7 @@ shared_examples 'config' do |parameter, _facts|
           'owner'   => 'opensearch',
           'group'   => 'opensearch',
           'mode'    => '0640',
-          'content' => data.to_yaml,
+          'content' => settings.to_yaml,
         }
       )
     }
@@ -57,7 +46,7 @@ shared_examples 'config' do |parameter, _facts|
           'owner'   => 'opensearch',
           'group'   => 'opensearch',
           'mode'    => '0640',
-          'content' => %r{-Xms#{heap_size}},
+          'content' => %r{-Xms#{parameter['heap_size']}},
         }
       )
     }

--- a/spec/shared_examples/install_archive.rb
+++ b/spec/shared_examples/install_archive.rb
@@ -5,17 +5,13 @@ shared_examples 'install_archive' do |parameter, _facts|
     is_expected.to contain_class('opensearch::install::archive')
   }
 
-  architecture = parameter['package_architecture']
-  directory    = parameter['package_directory']
-  ensure_value = parameter['package_ensure']
-  version      = parameter['version']
-  file         = "opensearch-#{version}-linux-#{architecture}.tar.gz"
+  file = "opensearch-#{parameter['version']}-linux-#{parameter['package_architecture']}.tar.gz"
 
   it {
     is_expected.to contain_user('opensearch').with(
       {
-        'ensure'     => ensure_value,
-        'home'       => directory,
+        'ensure'     => parameter['package_ensure'],
+        'home'       => parameter['package_directory'],
         'managehome' => false,
         'system'     => true,
         'shell'      => '/bin/false',
@@ -23,9 +19,9 @@ shared_examples 'install_archive' do |parameter, _facts|
     )
   }
 
-  if ensure_value == 'present'
+  if parameter['package_ensure'] == 'present'
     it {
-      is_expected.to contain_file(directory).with(
+      is_expected.to contain_file(parameter['package_directory']).with(
         {
           'ensure' => 'directory',
           'owner'  => 'opensearch',
@@ -60,21 +56,21 @@ shared_examples 'install_archive' do |parameter, _facts|
           'provider'        => 'wget',
           'path'            => "/tmp/#{file}",
           'extract'         => true,
-          'extract_path'    => directory,
-          'extract_command' => "tar -xvzf /tmp/#{file} --wildcards opensearch-#{version}/* -C #{directory}",
+          'extract_path'    => parameter['package_directory'],
+          'extract_command' => "tar -xvzf /tmp/#{file} --wildcards opensearch-#{parameter['version']}/* -C #{parameter['package_directory']}",
           'user'            => 'opensearch',
           'group'           => 'opensearch',
-          'creates'         => "#{directory}/bin",
+          'creates'         => "#{parameter['package_directory']}/bin",
           'cleanup'         => true,
-          'source'          => "https://artifacts.opensearch.org/releases/bundle/opensearch/#{version}/#{file}",
+          'source'          => "https://artifacts.opensearch.org/releases/bundle/opensearch/#{parameter['version']}/#{file}",
         }
       )
     }
   else
     it {
-      is_expected.to contain_file(directory).with(
+      is_expected.to contain_file(parameter['package_directory']).with(
         {
-          'ensure'  => ensure_value,
+          'ensure'  => parameter['package_ensure'],
           'revsere' => true,
           'force'   => true,
         }
@@ -84,7 +80,7 @@ shared_examples 'install_archive' do |parameter, _facts|
     it {
       is_expected.to contain_file('/var/lib/opensearch').with(
         {
-          'ensure'  => ensure_value,
+          'ensure'  => parameter['package_ensure'],
           'revsere' => true,
           'force'   => true,
         }
@@ -94,7 +90,7 @@ shared_examples 'install_archive' do |parameter, _facts|
     it {
       is_expected.to contain_file('/var/log/opensearch').with(
         {
-          'ensure'  => ensure_value,
+          'ensure'  => parameter['package_ensure'],
           'revsere' => true,
           'force'   => true,
         }

--- a/spec/shared_examples/install_package.rb
+++ b/spec/shared_examples/install_package.rb
@@ -5,16 +5,11 @@ shared_examples 'install_package' do |parameter, _facts|
     is_expected.to contain_class('opensearch::install::package')
   }
 
-  architecture = parameter['package_architecture']
-  ensure_value = parameter['package_ensure']
-  provider     = parameter['package_provider']
-  version      = parameter['version']
-
-  file = case provider
+  file = case parameter['package_provider']
          when 'dpkg'
-           "opensearch-#{version}-linux-#{architecture}.deb"
+           "opensearch-#{parameter['version']}-linux-#{parameter['package_architecture']}.deb"
          when 'rpm'
-           "opensearch-#{version}-linux-#{architecture}.rpm"
+           "opensearch-#{parameter['version']}-linux-#{parameter['package_architecture']}.rpm"
          end
 
   it {
@@ -23,7 +18,7 @@ shared_examples 'install_package' do |parameter, _facts|
         'provider' => 'wget',
         'extract'  => false,
         'cleanup'  => true,
-        'source'   => "https://artifacts.opensearch.org/releases/bundle/opensearch/#{version}/#{file}",
+        'source'   => "https://artifacts.opensearch.org/releases/bundle/opensearch/#{parameter['version']}/#{file}",
       }
     )
   }
@@ -31,8 +26,8 @@ shared_examples 'install_package' do |parameter, _facts|
   it {
     is_expected.to contain_package('opensearch').with(
       {
-        'ensure'   => ensure_value,
-        'provider' => provider,
+        'ensure'   => parameter['package_ensure'],
+        'provider' => parameter['package_provider'],
         'source'   => "/tmp/#{file}",
       }
     )

--- a/spec/shared_examples/install_repository_debian.rb
+++ b/spec/shared_examples/install_repository_debian.rb
@@ -5,12 +5,10 @@ shared_examples 'install_repository_debian' do |parameter, _facts|
     is_expected.to contain_class('opensearch::install::repository::debian')
   }
 
-  ensure_value = parameter['package_ensure']
-
   it {
     is_expected.to contain_archive('/tmp/opensearch.pgp').with(
       {
-        'ensure'          => ensure_value,
+        'ensure'          => parameter['package_ensure'],
         'source'          => 'https://artifacts.opensearch.org/publickeys/opensearch.pgp',
         'extract'         => true,
         'extract_path'    => '/usr/share/keyrings',
@@ -23,7 +21,7 @@ shared_examples 'install_repository_debian' do |parameter, _facts|
   it {
     is_expected.to contain_apt__source('opensearch').with(
       {
-        'ensure'   => ensure_value,
+        'ensure'   => parameter['package_ensure'],
         'location' => 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt',
         'release'  => 'stable',
         'repos'    => 'main',
@@ -35,7 +33,7 @@ shared_examples 'install_repository_debian' do |parameter, _facts|
   it {
     is_expected.to contain_package('opensearch').with(
       {
-        'ensure' => ensure_value,
+        'ensure' => parameter['package_ensure'],
       }
     )
   }

--- a/spec/shared_examples/install_repository_redhat.rb
+++ b/spec/shared_examples/install_repository_redhat.rb
@@ -5,12 +5,10 @@ shared_examples 'install_repository_redhat' do |parameter, _facts|
     is_expected.to contain_class('opensearch::install::repository::redhat')
   }
 
-  ensure_value = parameter['package_ensure']
-
   it {
     is_expected.to contain_yumrepo('OpenSearch 2.x').with(
       {
-        'ensure'        => ensure_value,
+        'ensure'        => parameter['package_ensure'],
         'baseurl'       => 'https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/yum',
         'repo_gpgcheck' => '1',
         'gpgcheck'      => '1',
@@ -22,7 +20,7 @@ shared_examples 'install_repository_redhat' do |parameter, _facts|
   it {
     is_expected.to contain_package('opensearch').with(
       {
-        'ensure' => ensure_value,
+        'ensure' => parameter['package_ensure'],
       }
     )
   }

--- a/templates/jvm.options.epp
+++ b/templates/jvm.options.epp
@@ -19,8 +19,8 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
--Xms<%= $heap_size %>
--Xmx<%= $heap_size %>
+-Xms<%= $opensearch::heap_size %>
+-Xmx<%= $opensearch::heap_size %>
 
 ################################################################
 ## Expert settings


### PR DESCRIPTION
Private classes with parameters make it possible for end-users to pass
custom values to these private classes via Hiera and break things.

If we do not have such parameters, we make breakage less likely.
