### PR TITLE
Relax dependencies version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     },
     {
       "name": "puppet/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 2.10.0 < 5.0.0"
+      "version_requirement": ">= 2.10.0 < 6.0.0"
     },
     {
       "name": "puppet/yum",

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 2.0.0 < 7.0.0"
+      "version_requirement": ">= 2.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
- Allow puppetlabs-stdlib 9.x
- Allow puppet-systemd 5.x
- Allow puppet-archive 7.x
