### PR TITLE
Require stdlib 9.x

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class opensearch::config {
     }
 
     $settings = $opensearch::use_default_settings ? {
-      true  => merge($opensearch::default_settings, $opensearch::settings),
+      true  => $opensearch::default_settings + $opensearch::settings,
       false => $opensearch::settings,
     }
 
@@ -22,7 +22,7 @@ class opensearch::config {
       owner   => 'opensearch',
       group   => 'opensearch',
       mode    => '0640',
-      content => $settings.to_yaml,
+      content => $settings.stdlib::to_yaml,
     }
 
     file { "${config_directory}/jvm.options":

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.5 < 8.0.0"
+      "version_requirement": ">= 1.2.5 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "puppet/yum",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The merge function from stdlib 9 is deprecated. It can be replaced with native puppet code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
