### PR TITLE
Fix files recurse parameter when ensure => absent

### DIFF
--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -54,19 +54,19 @@ class opensearch::install::archive {
   } else {
     file { $opensearch::package_directory:
       ensure  => $opensearch::package_ensure,
-      revsere => true,
+      recurse => true,
       force   => true,
     }
 
     file { '/var/lib/opensearch':
       ensure  => $opensearch::package_ensure,
-      revsere => true,
+      recurse => true,
       force   => true,
     }
 
     file { '/var/log/opensearch':
       ensure  => $opensearch::package_ensure,
-      revsere => true,
+      recurse => true,
       force   => true,
     }
   }

--- a/spec/shared_examples/install_archive.rb
+++ b/spec/shared_examples/install_archive.rb
@@ -71,7 +71,7 @@ shared_examples 'install_archive' do |parameter|
       is_expected.to contain_file(parameter['package_directory']).with(
         {
           'ensure'  => parameter['package_ensure'],
-          'revsere' => true,
+          'recurse' => true,
           'force'   => true,
         }
       )
@@ -81,7 +81,7 @@ shared_examples 'install_archive' do |parameter|
       is_expected.to contain_file('/var/lib/opensearch').with(
         {
           'ensure'  => parameter['package_ensure'],
-          'revsere' => true,
+          'recurse' => true,
           'force'   => true,
         }
       )
@@ -91,7 +91,7 @@ shared_examples 'install_archive' do |parameter|
       is_expected.to contain_file('/var/log/opensearch').with(
         {
           'ensure'  => parameter['package_ensure'],
-          'revsere' => true,
+          'recurse' => true,
           'force'   => true,
         }
       )


### PR DESCRIPTION
The file resource does not have a `revsere` parameter, `recurse` was
expected.
