### PR TITLE
Fix installation from archive

### DIFF
--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -40,14 +40,12 @@ class opensearch::install::archive {
     }
 
     archive { "/tmp/${file}":
-      provider        => 'wget',
-      path            => "/tmp/${file}",
       extract         => true,
       extract_path    => $opensearch::package_directory,
-      extract_command => "tar -xvzf /tmp/${file} --wildcards opensearch-${opensearch::version}/* -C ${opensearch::package_directory}",
+      extract_command => "tar xf %s --strip-components 1 -C ${opensearch::package_directory}",
       user            => 'opensearch',
       group           => 'opensearch',
-      creates         => "${opensearch::package_directory}/bin",
+      creates         => "${opensearch::package_directory}/bin/opensearch",
       cleanup         => true,
       source          => "https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearch::version}/${file}",
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,8 +9,9 @@ class opensearch::service {
   if $opensearch::manage_service {
     if $opensearch::package_source == 'archive' {
       systemd::unit_file { 'opensearch.service':
-        ensure => 'present',
-        source => "puppet:///modules/${module_name}/opensearch.service",
+        ensure  => 'present',
+        content => epp('opensearch/opensearch.service.epp'),
+        notify  => Service['opensearch'],
       }
     }
 

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -33,4 +33,37 @@ describe 'opensearch' do
       it { is_expected.to contain 'http.port: 9200' }
     end
   end
+
+  context 'uninstall' do
+    it 'uninstalls' do
+      apply_manifest(<<~PP, catch_failures: true)
+        package { 'opensearch':
+          ensure => purged,
+        }
+      PP
+    end
+  end
+
+  context 'when installing from an archive' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PP
+          class { 'opensearch':
+            version        => '2.9.0',
+            package_source => 'archive',
+            settings       => {
+              # When installing from an archive, the demo certificates are not
+              # installed by default.
+              'plugins.security.disabled' => true,
+            },
+          }
+        PP
+      end
+    end
+
+    describe service('opensearch') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
 end

--- a/spec/shared_examples/install_archive.rb
+++ b/spec/shared_examples/install_archive.rb
@@ -53,14 +53,12 @@ shared_examples 'install_archive' do |parameter|
     it {
       is_expected.to contain_archive("/tmp/#{file}").with(
         {
-          'provider'        => 'wget',
-          'path'            => "/tmp/#{file}",
           'extract'         => true,
           'extract_path'    => parameter['package_directory'],
-          'extract_command' => "tar -xvzf /tmp/#{file} --wildcards opensearch-#{parameter['version']}/* -C #{parameter['package_directory']}",
+          'extract_command' => "tar xf %s --strip-components 1 -C #{parameter['package_directory']}",
           'user'            => 'opensearch',
           'group'           => 'opensearch',
-          'creates'         => "#{parameter['package_directory']}/bin",
+          'creates'         => "#{parameter['package_directory']}/bin/opensearch",
           'cleanup'         => true,
           'source'          => "https://artifacts.opensearch.org/releases/bundle/opensearch/#{parameter['version']}/#{file}",
         }

--- a/spec/shared_examples/service.rb
+++ b/spec/shared_examples/service.rb
@@ -11,7 +11,7 @@ shared_examples 'service' do |parameter, _facts|
         is_expected.to contain_systemd__unit_file('opensearch.service').with(
           {
             'ensure' => 'present',
-            'source' => 'puppet:///modules/opensearch/opensearch.service',
+            'content' => %r{ExecStart=/opt/opensearch/bin/opensearch},
           }
         )
       }

--- a/templates/opensearch.service.epp
+++ b/templates/opensearch.service.epp
@@ -9,14 +9,14 @@ Description=Opensearch
 Documentation=https://opensearch.org/docs/latest
 Requires=network.target
 After=network.target
-ConditionPathExists=/opt/opensearch
+ConditionPathExists=<%= $opensearch::package_directory %>
 ConditionPathExists=/var/lib/opensearch
 
 [Service]
 User=opensearch
 Group=opensearch
-WorkingDirectory=/opt/opensearch
-ExecStart=/opt/opensearch/bin/opensearch
+WorkingDirectory=<%= $opensearch::package_directory %>
+ExecStart=<%= $opensearch::package_directory %>/bin/opensearch
 
 
 # Specifies the maximum file descriptor number that can be opened by this process


### PR DESCRIPTION
This was untested and broken.  The systemd unit customization was missing, add it as an EPP template so that user-defined installation directory is working.
