### PR TITLE
Add a name to the yum repository

### DIFF
--- a/manifests/repository/redhat.pp
+++ b/manifests/repository/redhat.pp
@@ -13,6 +13,7 @@ class opensearch::repository::redhat {
 
   yumrepo { 'opensearch':
     ensure        => $opensearch::repository_ensure,
+    descr         => 'OpenSearch',
     baseurl       => $baseurl,
     repo_gpgcheck => '1',
     gpgcheck      => '1',


### PR DESCRIPTION
Fix warning:
Repository 'opensearch' is missing name in configuration, using id
