### PR TITLE
Add workaround for initial admin password

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@ fixtures:
     apt: https://github.com/puppetlabs/puppetlabs-apt
     archive: https://github.com/voxpupuli/puppet-archive
     augeas: https://github.com/puppetlabs/puppetlabs-augeas_core
+    extlib: https://github.com/voxpupuli/puppet-extlib
     concat: https://github.com/puppetlabs/puppetlabs-concat
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
     systemd: https://github.com/voxpupuli/puppet-systemd

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
       "version_requirement": ">= 1.2.5 < 10.0.0"
     },
     {
+      "name": "puppet/extlib",
+      "version_requirement": ">= 3.0.0 < 8.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 9.0.0 < 10.0.0"
     },


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds an workaround to the current required setting of an initial admin password to be able to install the debian package.

#### This Pull Request (PR) fixes the following issues
Fixes #55
