### PR TITLE
support opensearch 3.x

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -636,7 +636,6 @@ opensearch::default_settings:
   cluster.initial_cluster_manager_nodes: "%{facts.networking.hostname}"
   discovery.seed_hosts:
   - 127.0.0.1
-  gateway.recover_after_nodes: 0
   http.port: 9200
   network.host: 127.0.0.1
   node.max_local_storage_nodes: 3

--- a/spec/helper/get_defaults.rb
+++ b/spec/helper/get_defaults.rb
@@ -21,7 +21,6 @@ def get_defaults(facts)
     'discovery.seed_hosts'                                         => [
       '127.0.0.1',
     ],
-    'gateway.recover_after_nodes'                                  => 0,
     'http.port'                                                    => 9200,
     'network.host'                                                 => '127.0.0.1',
     'node.max_local_storage_nodes'                                 => 3,

--- a/templates/jvm.options.epp
+++ b/templates/jvm.options.epp
@@ -77,8 +77,21 @@
 <%= $setting %>
 <% } -%>
 
+<% if $opensearch::version =~ Undef or versioncmp($opensearch::version, '3') >= 0 { -%>
+# JDK 20+ Incubating Vector Module for SIMD optimizations;
+# disabling may reduce performance on vector optimized lucene
+20-:--add-modules=jdk.incubator.vector
+
+# See please https://bugs.openjdk.org/browse/JDK-8341127 (openjdk/jdk#21283)
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
+
+21-:-javaagent:agent/opensearch-agent.jar
+21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+<% } else { -%>
 # Explicitly allow security manager (https://bugs.openjdk.java.net/browse/JDK-8270380)
 18-:-Djava.security.manager=allow
+<% } -%>
 
 ## OpenSearch Performance Analyzer
 -Dclk.tck=100


### PR DESCRIPTION
#### Pull Request (PR) description

Support opensearch 3.x.

#### This Pull Request (PR) fixes the following issues
Fixes #68

#### Notes and Caveats

This includes a change to the default config (remove `gateway.recover_after_nodes`) which affects earlier opensearch versions. Since the value removed is the default, there should be no net change, but this may trigger restarts, depending on the value of `restart_on_config_change`.

I have only put this in use enough to see that it seems to work. There may be some things for which I have failed to account.

I'm only working with opensearch 3.4, though I suspect other 3.x versions will work ok, since the changes are so minimal.

Installation via package only works on RHEL-based systems, not Debian-based systems. This is due to a pre-existing bug and is not specific to opensearch 3.x:
https://github.com/voxpupuli/puppet-opensearch/issues/55 which is actually an upstream bug; I commented on this here: https://github.com/opensearch-project/opensearch-build/pull/5554#issuecomment-3857910241

Integration tests fail for the same reason as above.